### PR TITLE
Upgrade WFA from commonJS only to commonJS + ES6 module

### DIFF
--- a/CK.AspNet.Auth/CK.AspNet.Auth.csproj
+++ b/CK.AspNet.Auth/CK.AspNet.Auth.csproj
@@ -6,7 +6,7 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="CSemVer" Version="9.0.4" />
+    <PackageReference Include="CSemVer" Version="9.1.0" />
     <PackageReference Include="CK.Auth.Abstractions" Version="$(CKAuthAbstractionsVersion)" />
     <PackageReference Include="CK.ActivityMonitor.SimpleSender" Version="$(CKActivityMonitorVersion)" />
     <PackageReference Include="CK.AspNet" Version="$(CKAspNetVersion)" />

--- a/Clients/webfrontauth-ngx/projects/webfrontauth-ngx/src/lib/AuthInterceptor.ts
+++ b/Clients/webfrontauth-ngx/projects/webfrontauth-ngx/src/lib/AuthInterceptor.ts
@@ -14,6 +14,7 @@ export class AuthInterceptor implements HttpInterceptor {
     public intercept(request: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
         return next.handle(
             this.authService.token !== ''
+            && this.authService.shouldSetToken(request.url!)
                 ? request.clone({headers: request.headers.set('Authorization', 'Bearer ' + this.authService.token)})
                 : request
         );

--- a/Clients/webfrontauth-ngx/projects/webfrontauth-ngx/src/lib/AuthInterceptor.ts
+++ b/Clients/webfrontauth-ngx/projects/webfrontauth-ngx/src/lib/AuthInterceptor.ts
@@ -13,8 +13,7 @@ export class AuthInterceptor implements HttpInterceptor {
 
     public intercept(request: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
         return next.handle(
-            this.authService.token !== ''
-            && request.url
+            request.url
             && this.authService.shouldSetToken(request.url)
                 ? request.clone({headers: request.headers.set('Authorization', 'Bearer ' + this.authService.token)})
                 : request

--- a/Clients/webfrontauth-ngx/projects/webfrontauth-ngx/src/lib/AuthInterceptor.ts
+++ b/Clients/webfrontauth-ngx/projects/webfrontauth-ngx/src/lib/AuthInterceptor.ts
@@ -14,7 +14,8 @@ export class AuthInterceptor implements HttpInterceptor {
     public intercept(request: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
         return next.handle(
             this.authService.token !== ''
-            && this.authService.shouldSetToken(request.url!)
+            && request.url
+            && this.authService.shouldSetToken(request.url)
                 ? request.clone({headers: request.headers.set('Authorization', 'Bearer ' + this.authService.token)})
                 : request
         );

--- a/Clients/webfrontauth/package-lock.json
+++ b/Clients/webfrontauth/package-lock.json
@@ -1634,7 +1634,7 @@
     },
     "escape-string-regexp": {
       "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "resolved": "https://invenietis.pkgs.visualstudio.com/_packaging/InternalNPM/npm/registry/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
       "dev": true
     },

--- a/Clients/webfrontauth/ts/src/AuthService.ts
+++ b/Clients/webfrontauth/ts/src/AuthService.ts
@@ -463,11 +463,16 @@ export class AuthService<T extends IUserInfo = IUserInfo> {
     }
 
     /**
-     * Checking that url is the same as configuration to authorize the addition of the token.
-     * @param url url where add the bearer token.
+     * Checks whether calling the provided url requires the header bearer token to be added or not.
+     * Currently, only urls from the authentication endpoint should add the authentication token.
+     * The url must exactly starts with the authentication backend address.
+     * In the future, this may be extended to support other secure endpoints if needed.
+     * @param url The url to be checked.
      */
     public shouldSetToken(url : string) : boolean {
-        return url!.startsWith(this._configuration.webFrontAuthEndPoint);
+        if(!url) throw new Error("Url should not be null or undefined")
+        if(this._token != "") return false;
+        return url.startsWith(this._configuration.webFrontAuthEndPoint);
     }
 
     //#endregion

--- a/Clients/webfrontauth/ts/src/AuthService.ts
+++ b/Clients/webfrontauth/ts/src/AuthService.ts
@@ -471,7 +471,7 @@ export class AuthService<T extends IUserInfo = IUserInfo> {
      */
     public shouldSetToken(url : string) : boolean {
         if(!url) throw new Error("Url should not be null or undefined")
-        if(this._token != "") return false;
+        if(this._token !== "") return false;
         return url.startsWith(this._configuration.webFrontAuthEndPoint);
     }
 

--- a/Clients/webfrontauth/ts/src/AuthService.ts
+++ b/Clients/webfrontauth/ts/src/AuthService.ts
@@ -471,7 +471,7 @@ export class AuthService<T extends IUserInfo = IUserInfo> {
      */
     public shouldSetToken(url : string) : boolean {
         if(!url) throw new Error("Url should not be null or undefined")
-        if(this._token !== "") return false;
+        if(this._token === "") return false;
         return url.startsWith(this._configuration.webFrontAuthEndPoint);
     }
 

--- a/Clients/webfrontauth/ts/src/AuthService.ts
+++ b/Clients/webfrontauth/ts/src/AuthService.ts
@@ -13,7 +13,7 @@ export class AuthService<T extends IUserInfo = IUserInfo> {
     private _refreshable: boolean;
     private _availableSchemes: ReadonlyArray<string>;
     private _endPointVersion: string;
-    private _configuration: AuthServiceConfiguration;    
+    private _configuration: AuthServiceConfiguration;
     private _currentError?: IWebFrontAuthError;
 
     private _axiosInstance: AxiosInstance;
@@ -39,7 +39,7 @@ export class AuthService<T extends IUserInfo = IUserInfo> {
     /** Gets the current error if any. */
     public get currentError(): IWebFrontAuthError|undefined { return this._currentError; }
     /** Gets the TypeSystem that manages AuthenticationInfo and UserInfo.*/
-    public get typeSystem(): IAuthenticationInfoTypeSystem<T> { return this._typeSystem; }   
+    public get typeSystem(): IAuthenticationInfoTypeSystem<T> { return this._typeSystem; }
 
     public get popupDescriptor(): PopupDescriptor {
         if (!this._popupDescriptor) { this._popupDescriptor = new PopupDescriptor(); }
@@ -163,8 +163,7 @@ export class AuthService<T extends IUserInfo = IUserInfo> {
     private onIntercept(): (value: AxiosRequestConfig) => AxiosRequestConfig | Promise<AxiosRequestConfig> {
         return (config: AxiosRequestConfig) => {
             if( this._token
-                && config.url 
-                && config.url.startsWith(this._configuration.webFrontAuthEndPoint) ) {
+                && this.shouldSetToken(config.url!) ) {
                     Object.assign(config.headers, { Authorization: `Bearer ${this._token}` });
             }
             return config;
@@ -214,20 +213,20 @@ export class AuthService<T extends IUserInfo = IUserInfo> {
                 this.localDisconnect();
             }
         } catch (error) {
-            
+
             // This should not happen too often nor contain dangerous secrets...
             console.log( 'Exception while sending '+entryPoint+' request.', error );
-            
+
             const axiosError = error as AxiosError;
             if (!(axiosError && axiosError.response)) {
                 // Connection issue.
-                if( entryPoint !== 'impersonate' 
+                if( entryPoint !== 'impersonate'
                     && entryPoint !== 'logout' ) {
 
                     const storage = this._configuration.useLocalStorage( entryPoint );
                     if( storage ) {
-                        const [auth,schemes] = this._typeSystem.authenticationInfo.loadFromLocalStorage( storage, 
-                                                                                        this._configuration.webFrontAuthEndPoint, 
+                        const [auth,schemes] = this._typeSystem.authenticationInfo.loadFromLocalStorage( storage,
+                                                                                        this._configuration.webFrontAuthEndPoint,
                                                                                         this._availableSchemes );
                         if( auth )
                         {
@@ -291,7 +290,7 @@ export class AuthService<T extends IUserInfo = IUserInfo> {
         this._token = r.token ? r.token : '';
         this._refreshable = r.refreshable ? r.refreshable : false;
         this._rememberMe = r.rememberMe ? r.rememberMe : false;
-        
+
         const info = this._typeSystem.authenticationInfo.fromJson(r.info, this._availableSchemes);
         if( info ) this._authenticationInfo = info;
         else this._authenticationInfo = this._typeSystem.authenticationInfo.none;
@@ -302,17 +301,17 @@ export class AuthService<T extends IUserInfo = IUserInfo> {
         }
         if( this._configuration.localStorage )
         {
-            this._typeSystem.authenticationInfo.saveToLocalStorage( 
-                    this._configuration.localStorage, 
-                    this._configuration.webFrontAuthEndPoint, 
-                    this._authenticationInfo, 
+            this._typeSystem.authenticationInfo.saveToLocalStorage(
+                    this._configuration.localStorage,
+                    this._configuration.webFrontAuthEndPoint,
+                    this._authenticationInfo,
                     this._availableSchemes );
             }
         this.onChange();
     }
 
     private localDisconnect( authInfo?: IAuthenticationInfoImpl<T> ): void {
-        // Keep the current rememberMe configuration: this is the "local" disconnect. 
+        // Keep the current rememberMe configuration: this is the "local" disconnect.
         this._token = '';
         this._refreshable = false;
         if( authInfo ) this._authenticationInfo = authInfo;
@@ -356,11 +355,11 @@ export class AuthService<T extends IUserInfo = IUserInfo> {
 
     /**
      * Refreshes the current authentication.
-     * @param full True to force a full refresh of the authentication: the server will 
+     * @param full True to force a full refresh of the authentication: the server will
      * challenge again the authentication against its backend.
-     * @param requestSchemes True to force a refresh of the availableSchemes (this is automatically 
-     * true when current availableSchemes is empty). 
-     * @param requestVersion True to force a refresh of the version (this is automatically 
+     * @param requestSchemes True to force a refresh of the availableSchemes (this is automatically
+     * true when current availableSchemes is empty).
+     * @param requestVersion True to force a refresh of the version (this is automatically
      * true when current endPointVersion is the empty string).
      */
     public async refresh(full: boolean = false, requestSchemes: boolean = false, requestVersion: boolean = false): Promise<void> {
@@ -386,17 +385,17 @@ export class AuthService<T extends IUserInfo = IUserInfo> {
      */
     public async logout(full: boolean = false): Promise<void> {
         this._token = '';
-        await this.sendRequest('logout', { queries: full ? ['full'] : [] }, /* skipResponseHandling */ true);   
+        await this.sendRequest('logout', { queries: full ? ['full'] : [] }, /* skipResponseHandling */ true);
         if( full ) {
             if( this._configuration.localStorage ) {
-                this._typeSystem.authenticationInfo.saveToLocalStorage( 
-                    this._configuration.localStorage, 
+                this._typeSystem.authenticationInfo.saveToLocalStorage(
+                    this._configuration.localStorage,
                     this._configuration.webFrontAuthEndPoint,
                     null,
                     []
                      )
             }
-        }    
+        }
         await this.refresh();
     }
 
@@ -407,12 +406,12 @@ export class AuthService<T extends IUserInfo = IUserInfo> {
             returnUrl = document.location.origin + returnUrl;
         }
         const queries = [
-            { key: 'scheme', value: scheme }, 
+            { key: 'scheme', value: scheme },
             { key: 'returnUrl', value: encodeURI(returnUrl) },
-            { key: 'callerOrigin', value: encodeURI(document.location.origin) }            
+            { key: 'callerOrigin', value: encodeURI(document.location.origin) }
          ];
-        // If rememberMe is not defined, the backend will use the current one (if any) and 
-        // will eventually default to false. 
+        // If rememberMe is not defined, the backend will use the current one (if any) and
+        // will eventually default to false.
         if( rememberMe !== undefined ) queries.push( { key: 'rememberMe', value: rememberMe ? "1" : "0" } );
         await this.sendRequest('startLogin', { body: userData, queries });
     }
@@ -448,19 +447,27 @@ export class AuthService<T extends IUserInfo = IUserInfo> {
                 }
             }
 
-            const eOnClick = popup.document.getElementById('submit-button'); 
+            const eOnClick = popup.document.getElementById('submit-button');
             if( eOnClick == null ) throw new Error( "Unable to find required 'submit-button' element." );
             eOnClick.onclick = (async () => await onClick());
-        } 
+        }
         else {
             const url = `${this._configuration.webFrontAuthEndPoint}.webfront/c/startLogin`;
             userData = { ...userData, callerOrigin: document.location.origin, rememberMe: rememberMe };
-            const queryString = userData 
+            const queryString = userData
                                 ? Object.keys(userData).map((key) => encodeURIComponent(key) + '=' + encodeURIComponent(userData![key] as string)).join('&')
                                 : '';
             const finalUrl = url + '?scheme=' + scheme + ((queryString !== '') ? '&' + queryString : '');
             window.open(finalUrl, this.popupDescriptor.popupTitle, this.popupDescriptor.features);
         }
+    }
+
+    /**
+     * Checking that url is the same as configuration to authorize the addition of the token.
+     * @param url url where add the bearer token.
+     */
+    public shouldSetToken(url : string) : boolean {
+        return url!.startsWith(this._configuration.webFrontAuthEndPoint);
     }
 
     //#endregion

--- a/CodeCakeBuilder/CodeCakeBuilder.csproj
+++ b/CodeCakeBuilder/CodeCakeBuilder.csproj
@@ -18,7 +18,7 @@
     <PackageReference Include="CK.Text" Version="9.0.0" />
     <PackageReference Include="NUnit.ConsoleRunner" Version="3.11.1" />
     <PackageReference Include="NUnit.Runners.Net4" Version="2.6.4" />
-    <PackageReference Include="SimpleGitVersion.Cake" Version="5.0.0" />
+    <PackageReference Include="SimpleGitVersion.Cake" Version="5.1.1" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
   </ItemGroup>
 </Project>

--- a/CodeCakeBuilder/dotnet/Build.NuGetArtifactType.cs
+++ b/CodeCakeBuilder/dotnet/Build.NuGetArtifactType.cs
@@ -93,7 +93,7 @@ if( GlobalInfo.BuildInfo.Version.PackageQuality <= CSemVer.PackageQuality.Stable
             /// <summary>
             /// Gets the local target feeds.
             /// </summary>
-            /// <returns>The set of remote NuGet feeds (in practice at moste one).</returns>
+            /// <returns>The set of remote NuGet feeds (in practice at most one).</returns>
             protected override IEnumerable<ArtifactFeed> GetLocalFeeds()
             {
                 return new NuGetHelper.NuGetFeed[] {

--- a/Common/Shared.props
+++ b/Common/Shared.props
@@ -1,14 +1,14 @@
 <Project>
   <PropertyGroup>
     <!-- Centralized dependencies versions. -->
-    <CKDatabaseVersion>16.1.0</CKDatabaseVersion>
-    <CKDBVersion>11.1.0</CKDBVersion>
-    <CKActivityMonitorVersion>14.1.0</CKActivityMonitorVersion>
+    <CKDatabaseVersion>16.1.1--0002-develop</CKDatabaseVersion>
+    <CKDBVersion>11.1.1--0002-develop</CKDBVersion>
+    <CKActivityMonitorVersion>14.1.1--0002-develop</CKActivityMonitorVersion>
     <CKMonitoringVersion>11.2.0</CKMonitoringVersion>
-    <CKAspNetVersion>7.1.0</CKAspNetVersion>
-    <CKAuthAbstractionsVersion>1.0.0</CKAuthAbstractionsVersion>
-    <CKAspNetTesterVersion>3.1.2</CKAspNetTesterVersion>
-    <CKDBUserUserPasswordVersion>11.1.0</CKDBUserUserPasswordVersion>
+    <CKAspNetVersion>7.1.1--0003-develop</CKAspNetVersion>
+    <CKAuthAbstractionsVersion>1.0.1--0004-develop</CKAuthAbstractionsVersion>
+    <CKAspNetTesterVersion>3.1.3--0004-develop</CKAspNetTesterVersion>
+    <CKDBUserUserPasswordVersion>11.1.1--0002-develop</CKDBUserUserPasswordVersion>
   </PropertyGroup>
   <!--<SourceLink>: is enabled only for ContinuousIntegrationBuild build. -->
   <ItemGroup Condition=" '$(ContinuousIntegrationBuild)' == 'true' ">


### PR DESCRIPTION
- Changes made in tsconfig.json to specifically target ES6 and make make a new "dist" folder which separate the compiled code in a clean way
- Created a new tsconfig for cjs (tsconfig-cjs.json) to also transpile ts in commonJS and put it in the right directory
- Changes made in package.json
  - set "main" property which is the primary entry point to cjs source to maintain good compatibility 
  - set "module" property which is link to es6 source, it will be used by tools that support this
  - and set "files" property to define all the files that should be included when we publish the module

This has already been tested with the package [webfrontauth-ngx](https://github.com/Invenietis/CK-AspNet-Auth/tree/master/Clients/webfrontauth-ngx), while explicitly targeting the cjs module angular was printing a warn about commonJS dependencies (see: https://angular.io/guide/build#configuring-commonjs-dependencies) and wasn't when targeting the es6 module in both case everything was working fine.