### PR TITLE
add cookie name in WebFrontAuthOptions

### DIFF
--- a/CK.AspNet.Auth/WebFrontAuthOptions.cs
+++ b/CK.AspNet.Auth/WebFrontAuthOptions.cs
@@ -154,5 +154,12 @@ namespace CK.AspNet.Auth
         /// It is null by default: no schemes elevate a critical authentication level.
         /// </summary>
         public IDictionary<string, TimeSpan>? SchemesCriticalTimeSpan { get; set; }
+
+        /// <summary>
+        /// Gets or sets the initial AuthCookieName. Defaults to ".webFront".
+        /// The long term cookie name equals to AuthCookieName suffixed by "LT".
+        /// This cannot be changed dynamically.
+        /// </summary>
+        public string AuthCookieName { get; set; } = ".webFront";
     }
 }

--- a/CK.AspNet.Auth/WebFrontAuthService.cs
+++ b/CK.AspNet.Auth/WebFrontAuthService.cs
@@ -36,12 +36,12 @@ namespace CK.AspNet.Auth
         /// <summary>
         /// Name of the authentication cookie.
         /// </summary>
-        public const string AuthCookieName = ".webFront";
+        public string AuthCookieName { get; }
 
         /// <summary>
         /// Name of the long term authentication cookie.
         /// </summary>
-        public const string UnsafeCookieName = ".webFrontLT";
+        public string UnsafeCookieName => AuthCookieName + "LT";
 
         readonly IAuthenticationTypeSystem _typeSystem;
         readonly IWebFrontAuthLoginService _loginService;
@@ -105,6 +105,7 @@ namespace CK.AspNet.Auth
             _bearerHeaderName = initialOptions.BearerHeaderName;
             CookieMode = initialOptions.CookieMode;
             _cookiePolicy = initialOptions.CookieSecurePolicy;
+            AuthCookieName = initialOptions.AuthCookieName;
         }
 
         /// <summary>

--- a/Tests/CK.AspNet.Auth.Tests/AuthServer.cs
+++ b/Tests/CK.AspNet.Auth.Tests/AuthServer.cs
@@ -126,6 +126,8 @@ namespace CK.AspNet.Auth.Tests
             }
             HttpResponseMessage response = await Client.PostJSON( uri, body );
             response.EnsureSuccessStatusCode();
+
+            var cookieName = Options.Get( WebFrontAuthOptions.OnlyAuthenticationScheme ).AuthCookieName;
             switch( Options.Get( WebFrontAuthOptions.OnlyAuthenticationScheme ).CookieMode )
             {
                 case AuthenticationCookieMode.WebFrontPath:
@@ -133,14 +135,14 @@ namespace CK.AspNet.Auth.Tests
                         Client.Cookies.GetCookies( Server.BaseAddress ).Should().BeEmpty();
                         var all = Client.Cookies.GetCookies( new Uri( Server.BaseAddress, "/.webfront/c/" ) );
                         all.Should().HaveCount( 2 );
-                        CheckLongTermCookie( rememberMe, all );
+                        CheckLongTermCookie( rememberMe, all, cookieName );
                         break;
                     }
                 case AuthenticationCookieMode.RootPath:
                     {
                         var all = Client.Cookies.GetCookies( Server.BaseAddress );
                         all.Should().HaveCount( 2 );
-                        CheckLongTermCookie( rememberMe, all );
+                        CheckLongTermCookie( rememberMe, all, cookieName );
                         break;
                     }
                 case AuthenticationCookieMode.None:
@@ -158,9 +160,9 @@ namespace CK.AspNet.Auth.Tests
             c.RememberMe.Should().Be( rememberMe );
             return c;
 
-            static void CheckLongTermCookie( bool rememberMe, System.Net.CookieCollection all )
+            static void CheckLongTermCookie( bool rememberMe, System.Net.CookieCollection all, string cookieName )
             {
-                var cookie = all.Single( c => c.Name == WebFrontAuthService.UnsafeCookieName ).Value;
+                var cookie = all.Single( c => c.Name == cookieName ).Value;
                 cookie = HttpUtility.UrlDecode( cookie );
                 var longTerm = JObject.Parse( cookie );
                 ((string)longTerm[StdAuthenticationTypeSystem.DeviceIdKeyType]).Should().NotBeEmpty( "There is always a non empty 'device' member." );
@@ -190,13 +192,13 @@ namespace CK.AspNet.Auth.Tests
                          break;
             }
 
-            string? authCookie = all?.SingleOrDefault( c => c.Name == WebFrontAuthService.AuthCookieName )?.Value;
+            string? authCookie = all?.SingleOrDefault( c => c.Name == Options.Get( WebFrontAuthOptions.OnlyAuthenticationScheme ).AuthCookieName )?.Value;
             JObject ltCookie = null;
             string? ltDeviceId = null;
             string? ltUserId = null;
             string? ltUserName = null;
 
-            var ltCookieStr = all?.SingleOrDefault( c => c.Name == WebFrontAuthService.UnsafeCookieName )?.Value;
+            var ltCookieStr = all?.SingleOrDefault( c => c.Name == Options.Get( WebFrontAuthOptions.OnlyAuthenticationScheme ).AuthCookieName + "LT" )?.Value;
             if( ltCookieStr != null )
             {
                 ltCookieStr = HttpUtility.UrlDecode( ltCookieStr );

--- a/Tests/CK.AspNet.Auth.Tests/AuthServer.cs
+++ b/Tests/CK.AspNet.Auth.Tests/AuthServer.cs
@@ -127,7 +127,7 @@ namespace CK.AspNet.Auth.Tests
             HttpResponseMessage response = await Client.PostJSON( uri, body );
             response.EnsureSuccessStatusCode();
 
-            var cookieName = Options.Get( WebFrontAuthOptions.OnlyAuthenticationScheme ).AuthCookieName;
+            var LTCookieName = Options.Get( WebFrontAuthOptions.OnlyAuthenticationScheme ).AuthCookieName + "LT";
             switch( Options.Get( WebFrontAuthOptions.OnlyAuthenticationScheme ).CookieMode )
             {
                 case AuthenticationCookieMode.WebFrontPath:
@@ -135,14 +135,14 @@ namespace CK.AspNet.Auth.Tests
                         Client.Cookies.GetCookies( Server.BaseAddress ).Should().BeEmpty();
                         var all = Client.Cookies.GetCookies( new Uri( Server.BaseAddress, "/.webfront/c/" ) );
                         all.Should().HaveCount( 2 );
-                        CheckLongTermCookie( rememberMe, all, cookieName );
+                        CheckLongTermCookie( rememberMe, all, LTCookieName );
                         break;
                     }
                 case AuthenticationCookieMode.RootPath:
                     {
                         var all = Client.Cookies.GetCookies( Server.BaseAddress );
                         all.Should().HaveCount( 2 );
-                        CheckLongTermCookie( rememberMe, all, cookieName );
+                        CheckLongTermCookie( rememberMe, all, LTCookieName );
                         break;
                     }
                 case AuthenticationCookieMode.None:

--- a/Tests/CK.AspNet.Auth.Tests/RememberMeTests.cs
+++ b/Tests/CK.AspNet.Auth.Tests/RememberMeTests.cs
@@ -30,6 +30,7 @@ namespace CK.AspNet.Auth.Tests
                 }
             } ) )
             {
+                var options = new WebFrontAuthOptions();
                 RefreshResponse auth = await s.LoginAlbertViaBasicProviderAsync( useGenericWrapper, rememberMe );
                 auth.Info.User.UserName.Should().Be( "Albert" );
                 auth.RememberMe.Should().Be( rememberMe );
@@ -41,7 +42,7 @@ namespace CK.AspNet.Auth.Tests
                 }
                 else
                 {
-                    var authCookie = cookies.Single( c => c.Name == WebFrontAuthService.AuthCookieName );
+                    var authCookie = cookies.Single( c => c.Name == options.AuthCookieName );
                     authCookie.Expires.Should().Be( DateTime.MinValue, "RememberMe is false: the authentication cookie uses a session lifetime." );
                 }
             }


### PR DESCRIPTION
Adding AuthCookieName into WebFrontAuthOptions. The AuthCookieName can be set with the options. The long term cookie name equals to AuthCookieName suffixed by "LT".