### PR TITLE
Add a new option to WebFrontAuthOptions : SlidingExpirationRefreshLimit:

### DIFF
--- a/CK.AspNet.Auth/WebFrontAuthOptions.cs
+++ b/CK.AspNet.Auth/WebFrontAuthOptions.cs
@@ -16,7 +16,7 @@ namespace CK.AspNet.Auth
         static readonly PathString _entryPath = new PathString( "/.webfront" );
 
         /// <summary>
-        /// The <see cref="WebFrontAuthService"/> is not designed to be added multiple 
+        /// The <see cref="WebFrontAuthService"/> is not designed to be added multiple
         /// times to an application, hence its name is unique.
         /// </summary>
         public const string OnlyAuthenticationScheme = "WebFrontAuth";
@@ -27,8 +27,8 @@ namespace CK.AspNet.Auth
         public PathString EntryPath => _entryPath;
 
         /// <summary>
-        /// Controls how much time the authentication will remain valid 
-        /// from the point it is created. 
+        /// Controls how much time the authentication will remain valid
+        /// from the point it is created.
         /// Defaults to 20 minutes.
         /// This time is extended if <see cref="SlidingExpirationTime"/> is set and
         /// when "<see cref="EntryPath"/>/c/refresh" is called.
@@ -38,8 +38,8 @@ namespace CK.AspNet.Auth
         public TimeSpan ExpireTimeSpan { get; set; } = TimeSpan.FromMinutes( 20 );
 
         /// <summary>
-        /// Controls how much time the long term, unsafe, authentication information 
-        /// will remain valid from the point it is created. 
+        /// Controls how much time the long term, unsafe, authentication information
+        /// will remain valid from the point it is created.
         /// Defaults to one year.
         /// This configuration can be changed dynamically.
         /// </summary>
@@ -80,7 +80,7 @@ namespace CK.AspNet.Auth
 
         /// <summary>
         /// Gets whether the authentication cookie (see <see cref="CookieMode"/>) requires or not https.
-        /// Note that the long term cookie uses <see cref="CookieOptions.Secure"/> sets to false since it 
+        /// Note that the long term cookie uses <see cref="CookieOptions.Secure"/> sets to false since it
         /// does not require any protection.
         /// Defaults to <see cref="CookieSecurePolicy.SameAsRequest"/>.
         /// This cannot be changed dynamically.
@@ -93,9 +93,9 @@ namespace CK.AspNet.Auth
         /// Defaults to <see cref="AuthenticationCookieMode.WebFrontPath"/>.
         /// </para>
         /// <para>
-        /// Setting it to <see cref="AuthenticationCookieMode.RootPath"/> should NOT BE used in 
+        /// Setting it to <see cref="AuthenticationCookieMode.RootPath"/> should NOT BE used in
         /// most cases: this mode, that is the same as the standard Cookie ASP.Net authentication,
-        /// is for standard and classical Web application. 
+        /// is for standard and classical Web application.
         /// </para>
         /// <para>
         /// Setting it to <see cref="AuthenticationCookieMode.None"/> disables all cookies: client apps
@@ -108,14 +108,14 @@ namespace CK.AspNet.Auth
         public AuthenticationCookieMode CookieMode { get; set; }
 
         /// <summary>
-        /// Gets or sets a list of available schemes returned for information from '/c/refresh' endpoint 
+        /// Gets or sets a list of available schemes returned for information from '/c/refresh' endpoint
         /// when 'schemes' appears in the query string.
         /// <para>
         /// Defaults to null: schemes are the same as <see cref="IWebFrontAuthLoginService.Providers"/>
         /// when this is null or empty.
         /// </para>
         /// <para>
-        /// When not null (or empty), this list takes precedence over the login service's providers: all supported 
+        /// When not null (or empty), this list takes precedence over the login service's providers: all supported
         /// schemes must be declared here (and unwanted ones must not appear).
         /// </para>
         /// <para>
@@ -130,12 +130,12 @@ namespace CK.AspNet.Auth
         public List<string>? AvailableSchemes { get; set; }
 
         /// <summary>
-        /// Gets or sets the refresh validation time. 
-        /// When set to other than <see cref="TimeSpan.Zero"/> the middleware will re-issue a new token 
-        /// (and new authentication cookie if <see cref="CookieMode"/> allows it) with a new expiration time any time it 
+        /// Gets or sets the refresh validation time.
+        /// When set to other than <see cref="TimeSpan.Zero"/> the middleware will re-issue a new token
+        /// (and new authentication cookie if <see cref="CookieMode"/> allows it) with a new expiration time any time it
         /// processes a ".webfront/c/refresh" request.
         /// <para>
-        /// This applies to <see cref="IAuthenticationInfo.Expires"/> but not to <see cref="IAuthenticationInfo.CriticalExpires"/>. 
+        /// This applies to <see cref="IAuthenticationInfo.Expires"/> but not to <see cref="IAuthenticationInfo.CriticalExpires"/>.
         /// This configuration can be changed dynamically: modifying the configuration will take the
         /// new value into account.
         /// </para>
@@ -185,8 +185,8 @@ namespace CK.AspNet.Auth
         /// <summary>
         /// Gets a mutable list of accepted returnUrl prefixes.
         /// <para>
-        /// The returnUrl optional parameter submitted to the '/c/startLogin' end point (case of an "inline login" based 
-        /// on page redirections rather that the recommended popup window) must exactly start with one of this 
+        /// The returnUrl optional parameter submitted to the '/c/startLogin' end point (case of an "inline login" based
+        /// on page redirections rather that the recommended popup window) must exactly start with one of this
         /// prefix (<see cref="StringComparison.Ordinal"/> is used) otherwise a 400 Bad Request error code is returned.
         /// </para>
         /// <para>

--- a/CK.AspNet.Auth/WebFrontAuthOptions.cs
+++ b/CK.AspNet.Auth/WebFrontAuthOptions.cs
@@ -143,6 +143,15 @@ namespace CK.AspNet.Auth
         public TimeSpan SlidingExpirationTime { get; set; }
 
         /// <summary>
+        /// When set to true and <see cref="SlidingExpirationTime"/> set to other than <see cref="TimeSpan.Zero"/>,
+        /// prevent the expiration time to be renew before the current expiration is halved. This prevent a behavior
+        /// where the cookie would be modified on each refresh call. It can be mandatory when working with
+        /// AntiForgeryToken.
+        /// You should set the same <see cref="SlidingExpirationTime"/> and <see cref="ExpireTimeSpan"/>.
+        /// </summary>
+        public bool SlidingExpirationRefreshLimit { get; set; }
+
+        /// <summary>
         /// Gets or sets the http header name. Defaults to "Authorization".
         /// This cannot be changed dynamically.
         /// </summary>

--- a/CK.AspNet.Auth/WebFrontAuthOptions.cs
+++ b/CK.AspNet.Auth/WebFrontAuthOptions.cs
@@ -148,6 +148,7 @@ namespace CK.AspNet.Auth
         /// where the cookie would be modified on each refresh call. It can be mandatory when working with
         /// AntiForgeryToken.
         /// You should set the same <see cref="SlidingExpirationTime"/> and <see cref="ExpireTimeSpan"/>.
+        /// This behavior mimic CookieAuthenticationOptions.SlidingExpiration : https://learn.microsoft.com/en-us/dotnet/api/microsoft.aspnetcore.authentication.cookies.cookieauthenticationoptions.slidingexpiration?view=aspnetcore-6.0.
         /// </summary>
         public bool SlidingExpirationRefreshLimit { get; set; }
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,7 +7,7 @@ environment:
   CODECAKEBUILDER_SECRET_KEY:
     secure: 8VAzdXgUQaJyFoU3WLf2iPFV/8zPDm9qV4TfOpx8/rg=
 install:
-  - ps: Install-Product node x64
+  - ps: Install-Product node '' x64
 test: off
 on_finish:
 - ps: "'Get-ChildItem -Recurse *.log | % { Push-AppveyorArtifact $_.FullName -FileName $_.Name -DeploymentName ''Log files'' }'"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,6 +6,8 @@ environment:
   SqlServer/MasterConnectionString: Server=(local)\SQL2017;Database=master;User ID=sa;Password=Password12!
   CODECAKEBUILDER_SECRET_KEY:
     secure: 8VAzdXgUQaJyFoU3WLf2iPFV/8zPDm9qV4TfOpx8/rg=
+install:
+  - ps: Install-Product node x64
 test: off
 on_finish:
 - ps: "'Get-ChildItem -Recurse *.log | % { Push-AppveyorArtifact $_.FullName -FileName $_.Name -DeploymentName ''Log files'' }'"


### PR DESCRIPTION
If set to true, it will behave kind of like dotnet cookie.
It means that the expiration time will be refreshed only when it processes a request which is more than halfway through the expiration window.
Since ExpirationTimeSpan and SlidingExpirationTime exists, this code will be ignored and throw a warning whenever those 2 values are not equals.

This commit has been issued to solve antiforgery issues.